### PR TITLE
allow MSP430 DCO frequency to be up to 9MHz

### DIFF
--- a/se/sics/mspsim/core/BasicClockModule.java
+++ b/se/sics/mspsim/core/BasicClockModule.java
@@ -57,7 +57,7 @@ public class BasicClockModule extends ClockSystem {
   // Max speed is 8Mhz (CPU limits it) - is max DCO 8Mhz?
   // Based on the scatterweb code it looks like less than
   // 5Mhz is more correct...
-  private static final int MAX_DCO_FRQ = 4915200;
+  private static final int MAX_DCO_FRQ = 9000000;
   private static final int MIN_DCO_FRQ = 1000;
   private static final int DCO_FACTOR = (MAX_DCO_FRQ - MIN_DCO_FRQ) / 2048;
 


### PR DESCRIPTION
This is a quick-and-dirty fix for msp430 Series-2 based mote (e.g. Zolertia Z1) clock speed in simulations. 

For now, attempts to configure DCO frequency higher than 4.9 MHz in Cooja lead to ACLK speed being reduced to 16384. The outcome is that Contiki system clock on simulated Z1 motes runs twice slower than expected.

Due to some implementation idiosyncrasies, the problem with Z1 clock speed in simulations appeared only after applying this pull request to Contiki: https://github.com/contiki-os/contiki/pull/606 (it fixes a different clock frequency related bug):

Related: issue #35.
