### PR TITLE
Bug Fix: IO range for adc12 one word to short

### DIFF
--- a/se/sics/mspsim/config/MSP430f1611Config.java
+++ b/se/sics/mspsim/config/MSP430f1611Config.java
@@ -113,7 +113,7 @@ public class MSP430f1611Config extends MSP430Config {
         cpu.setIORange(0x080, 16, adc12);
         cpu.setIORange(0x140, 16, adc12);
         cpu.setIORange(0x150, 16, adc12);
-        cpu.setIORange(0x1a0,  8, adc12);
+        cpu.setIORange(0x1a0, 10, adc12);
 
         return 3 + 6;
     }

--- a/se/sics/mspsim/config/MSP430f2617Config.java
+++ b/se/sics/mspsim/config/MSP430f2617Config.java
@@ -127,7 +127,7 @@ public class MSP430f2617Config extends MSP430Config {
         cpu.setIORange(0x080, 16, adc12);
         cpu.setIORange(0x140, 16, adc12);
         cpu.setIORange(0x150, 16, adc12);
-        cpu.setIORange(0x1a0,  8, adc12);
+        cpu.setIORange(0x1a0, 10, adc12);
 
         /* 4 usci units + 6 io port*/
         return 4 + 6;


### PR DESCRIPTION
Bug Fix, address 0x01A8, length 2, is also used by ADC12 (Interrupt vector word, ADC12IV). Referring to MSP430x1xx datasheet, 17-20, 17.3.