### PR TITLE
fixed configuration for maximum DCO clock speed

### DIFF
--- a/se/sics/mspsim/config/MSP430f2617Config.java
+++ b/se/sics/mspsim/config/MSP430f2617Config.java
@@ -134,6 +134,11 @@ public class MSP430f2617Config extends MSP430Config {
     }
 
     @Override
+    public int getMaxClockSpeed() {
+        return 9000000;
+    }
+
+    @Override
     public String getAddressAsString(int addr) {
         return Utils.hex20(addr);
     }

--- a/se/sics/mspsim/core/BasicClockModule.java
+++ b/se/sics/mspsim/core/BasicClockModule.java
@@ -57,9 +57,9 @@ public class BasicClockModule extends ClockSystem {
   // Max speed is 8Mhz (CPU limits it) - is max DCO 8Mhz?
   // Based on the scatterweb code it looks like less than
   // 5Mhz is more correct...
-  private static final int MAX_DCO_FRQ = 4915200;
-  private static final int MIN_DCO_FRQ = 1000;
-  private static final int DCO_FACTOR = (MAX_DCO_FRQ - MIN_DCO_FRQ) / 2048;
+  private final int MAX_DCO_FRQ;
+  private final int MIN_DCO_FRQ = 1000;
+  private final int DCO_FACTOR;
 
   private Timer[] timers;
 
@@ -81,8 +81,11 @@ public class BasicClockModule extends ClockSystem {
    * Creates a new <code>BasicClockModule</code> instance.
    *
    */
-  public BasicClockModule(MSP430Core core, int[] memory, int offset, Timer[] timers) {
+  public BasicClockModule(MSP430Core core, int[] memory, int offset, Timer[] timers, int maxClockSpeed) {
+
     super("BasicClockModule", core, memory, offset);
+    MAX_DCO_FRQ = maxClockSpeed;
+    DCO_FACTOR = (MAX_DCO_FRQ - MIN_DCO_FRQ) / 2048;
     this.timers = timers;
     //    reset(0);
   }

--- a/se/sics/mspsim/core/MSP430Config.java
+++ b/se/sics/mspsim/core/MSP430Config.java
@@ -152,12 +152,16 @@ public abstract class MSP430Config {
         ramMirrorAddress = address;
     }
 
+    public int getMaxClockSpeed() {
+        return 4915200;
+    }
+
     public void ioMemSize(int size) {
         maxMemIO = size;
     }
 
     public ClockSystem createClockSystem(MSP430Core cpu, int[] memory, Timer[] timers) {
-        return new BasicClockModule(cpu, memory, 0, timers);
+        return new BasicClockModule(cpu, memory, 0, timers, getMaxClockSpeed());
     }
 
 }


### PR DESCRIPTION
This fix adds the possibility to configure the max DCO clock speed used to clock the MCU. It defaults to the previously hardcoded value but adds a new value inspired from the pull request #38 to the f2xxx MCUs (used in Z1).