### PR TITLE
Fix .gitignore jar files rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.class
 
 # Package Files #
-./*.jar
+*.jar
 *.war
 *.ear
 


### PR DESCRIPTION
Unless I'm missing something, the rule is broken. Does not ignore mspsim.jar for instance.