### PR TITLE
Fix .gitignore jar files rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.class
 
 # Package Files #
-./*.jar
+/*.jar
 *.war
 *.ear
 


### PR DESCRIPTION
The rule was intended to ignore jar files at the top-level, but had a typo